### PR TITLE
Feature/driver command timeout

### DIFF
--- a/src/SeleniumFixture.xUnit/ChromeDriverAttribute.cs
+++ b/src/SeleniumFixture.xUnit/ChromeDriverAttribute.cs
@@ -3,7 +3,6 @@ using OpenQA.Selenium.Chrome;
 using SeleniumFixture.xUnit.Impl;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
 namespace SeleniumFixture.xUnit
 {
@@ -19,7 +18,7 @@ namespace SeleniumFixture.xUnit
             ReturnDriver(testMethod, driver as ChromeDriver);
         }
 
-        private ChromeDriver CreateWebDriver(MethodInfo testMethod)
+        public static ChromeDriver CreateWebDriver(MethodInfo testMethod)
         {
             ChromeDriver driver = null;
 
@@ -35,7 +34,7 @@ namespace SeleniumFixture.xUnit
 
                 var service = ChromeDriverService.CreateDefaultService();
                 var options = optionsProvider != null ? optionsProvider.ProvideOptions(testMethod) : new ChromeOptions();
-                var commandTimeout = this.GetWebDriverCommandTimeout(testMethod);
+                var commandTimeout = GetWebDriverCommandTimeout(testMethod);
 
                 driver = new ChromeDriver(service, options, commandTimeout);
             }

--- a/src/SeleniumFixture.xUnit/ChromeDriverAttribute.cs
+++ b/src/SeleniumFixture.xUnit/ChromeDriverAttribute.cs
@@ -3,6 +3,7 @@ using OpenQA.Selenium.Chrome;
 using SeleniumFixture.xUnit.Impl;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace SeleniumFixture.xUnit
 {
@@ -18,7 +19,7 @@ namespace SeleniumFixture.xUnit
             ReturnDriver(testMethod, driver as ChromeDriver);
         }
 
-        public static ChromeDriver CreateWebDriver(MethodInfo testMethod)
+        private ChromeDriver CreateWebDriver(MethodInfo testMethod)
         {
             ChromeDriver driver = null;
 
@@ -32,7 +33,11 @@ namespace SeleniumFixture.xUnit
             {
                 var optionsProvider = ReflectionHelper.GetAttribute<ChromeOptionsAttribute>(testMethod);
 
-                driver = new ChromeDriver(optionsProvider != null ? optionsProvider.ProvideOptions(testMethod) : new ChromeOptions());
+                var service = ChromeDriverService.CreateDefaultService();
+                var options = optionsProvider != null ? optionsProvider.ProvideOptions(testMethod) : new ChromeOptions();
+                var commandTimeout = this.GetWebDriverCommandTimeout(testMethod);
+
+                driver = new ChromeDriver(service, options, commandTimeout);
             }
 
             InitializeDriver(testMethod, driver);

--- a/src/SeleniumFixture.xUnit/EdgeDriverAttribute.cs
+++ b/src/SeleniumFixture.xUnit/EdgeDriverAttribute.cs
@@ -32,7 +32,11 @@ namespace SeleniumFixture.xUnit
             {
                 var optionsProvider = ReflectionHelper.GetAttribute<EdgeOptionsAttribute>(testMethod);
 
-                driver = new EdgeDriver(optionsProvider != null ? optionsProvider.ProvideOptions(testMethod) : new EdgeOptions());
+                var service = EdgeDriverService.CreateDefaultService();
+                var options = optionsProvider != null ? optionsProvider.ProvideOptions(testMethod) : new EdgeOptions();
+                var commandTimeout = GetWebDriverCommandTimeout(testMethod);
+
+                driver = new EdgeDriver(service, options, commandTimeout);
             }
 
             InitializeDriver(testMethod, driver);

--- a/src/SeleniumFixture.xUnit/FireFoxDriverAttribute.cs
+++ b/src/SeleniumFixture.xUnit/FireFoxDriverAttribute.cs
@@ -31,23 +31,25 @@ namespace SeleniumFixture.xUnit
             }
             else
             {
-                var optionsProvider = ReflectionHelper.GetAttribute<FirefoxOptionsAttribute>(testMethod);
-                var provider = ReflectionHelper.GetAttribute<FirefoxProfileAttribute>(testMethod);
+                var profileProvider = ReflectionHelper.GetAttribute<FirefoxProfileAttribute>(testMethod);
+                if (profileProvider != null)
+                {
+                    // depreicated provider
+                    var binary = new FirefoxBinary();
+                    var profile = profileProvider.CreateProfile(testMethod);
+                    var commandTimeout = GetWebDriverCommandTimeout(testMethod);
 
-                if (optionsProvider == null && provider == null)
-                {
-                    driver = new FirefoxDriver();
-                }
-                else if (optionsProvider != null)
-                {
-                    var options = optionsProvider.ProvideOptions(testMethod);
-                    var service = FirefoxDriverService.CreateDefaultService();
-                    driver = new FirefoxDriver(service, options, TimeSpan.FromSeconds(60));
+                    driver = new FirefoxDriver(binary, profile, commandTimeout);
                 }
                 else
                 {
-                    var profile = provider.CreateProfile(testMethod);
-                    driver = new FirefoxDriver(profile);
+                    var optionsProvider = ReflectionHelper.GetAttribute<FirefoxOptionsAttribute>(testMethod);
+
+                    var service = FirefoxDriverService.CreateDefaultService();
+                    var options = optionsProvider != null ? optionsProvider.ProvideOptions(testMethod) : new FirefoxOptions();
+                    var commandTimeout = GetWebDriverCommandTimeout(testMethod);
+
+                    driver = new FirefoxDriver(service, options, commandTimeout);
                 }
             }
 

--- a/src/SeleniumFixture.xUnit/InternetExplorerDriverAttribute.cs
+++ b/src/SeleniumFixture.xUnit/InternetExplorerDriverAttribute.cs
@@ -33,9 +33,11 @@ namespace SeleniumFixture.xUnit
             {
                 var optionsProvider = ReflectionHelper.GetAttribute<InternetExplorerOptionsAttribute>(testMethod);
 
-                driver = new InternetExplorerDriver(optionsProvider != null ?
-                                                  optionsProvider.ProvideOptions(testMethod) :
-                                                  new InternetExplorerOptions {  IgnoreZoomLevel = true });
+                var service = InternetExplorerDriverService.CreateDefaultService();
+                var options = optionsProvider != null ? optionsProvider.ProvideOptions(testMethod) : new InternetExplorerOptions { IgnoreZoomLevel = true };
+                var commandTimeout = GetWebDriverCommandTimeout(testMethod);
+
+                driver = new InternetExplorerDriver(service, options, commandTimeout);
             }
 
             InitializeDriver(testMethod, driver);

--- a/src/SeleniumFixture.xUnit/RemoteDriverAttribute.cs
+++ b/src/SeleniumFixture.xUnit/RemoteDriverAttribute.cs
@@ -116,7 +116,10 @@ namespace SeleniumFixture.xUnit
 
         public static IWebDriver CreateWebDriverInstance(MethodInfo testMethod, string hub, DesiredCapabilities capabilities)
         {
-            var driver = string.IsNullOrEmpty(hub) ? new RemoteWebDriver(capabilities) : new RemoteWebDriver(new Uri(hub), capabilities);
+            var commandTimeout = GetWebDriverCommandTimeout(testMethod);
+
+            // there is no overload that takes commandTimeout unless you provide a hub
+            var driver = string.IsNullOrEmpty(hub) ? new RemoteWebDriver(capabilities) : new RemoteWebDriver(new Uri(hub), capabilities, commandTimeout);
 
             InitializeDriver(testMethod, driver);
 

--- a/src/SeleniumFixture.xUnit/WebDriverAttribute.cs
+++ b/src/SeleniumFixture.xUnit/WebDriverAttribute.cs
@@ -8,6 +8,11 @@ namespace SeleniumFixture.xUnit
 {
     public abstract class WebDriverAttribute : Attribute
     {
+        /// <summary>
+        /// The default command timeout for HTTP requests in a RemoteWebDriver instance.
+        /// </summary>
+        protected static readonly TimeSpan DefaultCommandTimeout = TimeSpan.FromSeconds(60);
+
         private class InternalStorageHelper<T> where T : IWebDriver
         {
             private static InternalStorageHelper<T> _instance;
@@ -101,6 +106,12 @@ namespace SeleniumFixture.xUnit
                 driver.Manage().Window.Maximize();
                 driver.Navigate().GoToUrl("about:blank");
             }
+        }
+
+        protected TimeSpan GetWebDriverCommandTimeout(MethodInfo method)
+        {
+            var commandTimeoutAttribute = ReflectionHelper.GetAttribute<WebDriverCommandTimeoutAttribute>(method);
+            return commandTimeoutAttribute?.Timeout ?? DefaultCommandTimeout;
         }
 
         protected T GetSharedInstance<T>(Func<T> createMethod) where T : IWebDriver

--- a/src/SeleniumFixture.xUnit/WebDriverAttribute.cs
+++ b/src/SeleniumFixture.xUnit/WebDriverAttribute.cs
@@ -108,7 +108,7 @@ namespace SeleniumFixture.xUnit
             }
         }
 
-        protected TimeSpan GetWebDriverCommandTimeout(MethodInfo method)
+        protected static TimeSpan GetWebDriverCommandTimeout(MethodInfo method)
         {
             var commandTimeoutAttribute = ReflectionHelper.GetAttribute<WebDriverCommandTimeoutAttribute>(method);
             return commandTimeoutAttribute?.Timeout ?? DefaultCommandTimeout;

--- a/src/SeleniumFixture.xUnit/WebDriverCommandTimeoutAttribute.cs
+++ b/src/SeleniumFixture.xUnit/WebDriverCommandTimeoutAttribute.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace SeleniumFixture.xUnit
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public class WebDriverCommandTimeoutAttribute : Attribute
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="timeout">The maximum amount of time, in seconds, to wait for each command.</param>
+        public WebDriverCommandTimeoutAttribute(int timeout)
+        {
+            if (timeout <= 0)
+            {
+                throw new ArgumentOutOfRangeException("timeout must be greater than zero");
+            }
+
+            Timeout = TimeSpan.FromSeconds(timeout);
+        }
+
+        /// <summary>
+        /// The maximum amount of time to wait for each command.
+        /// </summary>
+        public TimeSpan Timeout { get; }
+    }
+}


### PR DESCRIPTION
Applied WebDriverCommandTimeoutAttribute to each driver. RemoteDriverAttribute has limitation on that if you don't have a hub, there is no constructor overload on RemoteWebDriver that accept timeout parameter.